### PR TITLE
new implementation of `three_qubit_realistic`; expanded test coverage

### DIFF
--- a/Implementation Knowledge Base/02c. 3 qubit logical T1 calculation.ipynb
+++ b/Implementation Knowledge Base/02c. 3 qubit logical T1 calculation.ipynb
@@ -19,6 +19,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c322e2c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e5a29833",
    "metadata": {},
    "outputs": [],
@@ -617,7 +628,7 @@
     "\n",
     "# Initialize our 3 qubit logical state\n",
     "rho = initialize_three_qubit_realisitc(\n",
-    "    initial_psi, t1 = t1, t2 = t2, tg = tg, qubit_error_probs=qubit_error_probs, spam=spam_prob)\n",
+    "    initial_psi, t1 = t1, t2 = t2, tg = tg, qubit_error_probs=qubit_error_probs, spam_prob=spam_prob)\n",
     "\n",
     "all_pops = np.array([])\n",
     "count = np.array([])\n",
@@ -710,7 +721,7 @@
     "\n",
     "# Initialize our 3 qubit logical state\n",
     "rho = initialize_three_qubit_realisitc(\n",
-    "    initial_psi, t1 = t1, t2 = t2, tg = tg, qubit_error_probs=qubit_error_probs, spam=spam_prob)\n",
+    "    initial_psi, t1 = t1, t2 = t2, tg = tg, qubit_error_probs=qubit_error_probs, spam_prob=spam_prob)\n",
     "\n",
     "all_pops = np.array([])\n",
     "count = np.array([])\n",
@@ -898,6 +909,14 @@
     "plt.legend()\n",
     "plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc7fc53e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/circuit_specific/realistic_three_qubit.py
+++ b/circuit_specific/realistic_three_qubit.py
@@ -6,8 +6,9 @@ import random
 
 import numpy as np
 from general_qec.qec_helpers import one, zero
-from general_qec.gates import CNOT
-from general_qec.errors import *
+from general_qec.gates import CNOT, sigma_x
+from general_qec.errors import prob_line_rad_CNOT, line_rad_CNOT, line_errored_CNOT
+from general_qec.errors import spam_error, gate_error, rad_error
 
 # Masurement operators for individual qubits
 zero_meas = np.kron(zero, zero[np.newaxis].conj().T)
@@ -86,7 +87,7 @@ def initialize_three_qubit_realisitc(            # pylint: disable=too-many-argu
 def three_qubit_realistic(
         initial_rho, t1=None, t2=None, tg=None,
         qubit_error_probs=None, spam_prob=None
-    ): # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements,too-many-branches
+    ): # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements
     """
     Implements the 3 qubit circuit with relaxation and dephasing errors, gate
     error probabilities, and spam errors.
@@ -111,13 +112,6 @@ def three_qubit_realistic(
     measure10 = np.kron(np.identity(2**3), np.kron(one_meas, zero_meas))
     measure11 = np.kron(np.identity(2**3), np.kron(one_meas, one_meas))
     all_meas = np.array([measure00, measure01, measure10, measure11])
-
-    # measurement_ops = np.array([
-    #     [np.kron(np.identity(2**3), np.kron(zero_meas, zero_meas)),
-    #      np.kron(np.identity(2**3), np.kron(zero_meas, one_meas))],
-    #     [np.kron(np.identity(2**3), np.kron(one_meas, zero_meas)),
-    #      np.kron(np.identity(2**3), np.kron(one_meas, one_meas))]
-    # ]).flatten()
 
     # Apply the CNOT gates needed to change the state of the syndrome ancilla
     detection_rho = initial_rho

--- a/circuit_specific/realistic_three_qubit.py
+++ b/circuit_specific/realistic_three_qubit.py
@@ -1,9 +1,12 @@
-# This file will contain functions that are useful when implementing logical t1 testing for the 3 qubit code from error models
+"""
+This file will contain functions that are useful when implementing logical t1
+testing for the 3 qubit code from error models.
+"""
+import random
 
 import numpy as np
-import random
-from general_qec.qec_helpers import *
-from general_qec.gates import *
+from general_qec.qec_helpers import one, zero
+from general_qec.gates import CNOT
 from general_qec.errors import *
 
 # Masurement operators for individual qubits
@@ -81,9 +84,9 @@ def initialize_three_qubit_realisitc(            # pylint: disable=too-many-argu
 
 
 def three_qubit_realistic(
-        initial_rho, t1=None, t2=None, tg=None, # pytlint: disable=invalid-name
-        qubit_error_probs = None, spam_prob = None
-    ):
+        initial_rho, t1=None, t2=None, tg=None,
+        qubit_error_probs=None, spam_prob=None
+    ): # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements,too-many-branches
     """
     Implements the 3 qubit circuit with relaxation and dephasing errors, gate
     error probabilities, and spam errors.
@@ -97,6 +100,136 @@ def three_qubit_realistic(
     * qubit_error_probs: an array of the probability for errors of each qubit in your system
     * spam_prob: The pobability that you have a state prep or measurement error
     Note: times are in seconds.
+    """
+    nqubits = int(np.log(len(initial_rho))/np.log(2))
+    apply_rad_errors = (t1 is not None) and (t2 is not None) and (tg is not None)
+    apply_krauss_errors = qubit_error_probs is not None
+    apply_spam_errors = spam_prob is not None
+    # Define the measurement projection operators
+    measure00 = np.kron(np.identity(2**3), np.kron(zero_meas, zero_meas))
+    measure01 = np.kron(np.identity(2**3), np.kron(zero_meas, one_meas))
+    measure10 = np.kron(np.identity(2**3), np.kron(one_meas, zero_meas))
+    measure11 = np.kron(np.identity(2**3), np.kron(one_meas, one_meas))
+    all_meas = np.array([measure00, measure01, measure10, measure11])
+
+    # measurement_ops = np.array([
+    #     [np.kron(np.identity(2**3), np.kron(zero_meas, zero_meas)),
+    #      np.kron(np.identity(2**3), np.kron(zero_meas, one_meas))],
+    #     [np.kron(np.identity(2**3), np.kron(one_meas, zero_meas)),
+    #      np.kron(np.identity(2**3), np.kron(one_meas, one_meas))]
+    # ]).flatten()
+
+    # Apply the CNOT gates needed to change the state of the syndrome ancilla
+    detection_rho = initial_rho
+    for (control, target) in [(0, 3), (1, 3), (0, 4), (2, 4)]:
+        detection_rho = prob_line_rad_CNOT(
+            detection_rho, control, target, t1, t2, tg, qubit_error_probs, form='rho')
+
+    # Measure the ancilla qubits
+    # -- 1st, apply state measurement error if spam_probs is not empty
+    if apply_spam_errors:
+        detection_rho = spam_error(detection_rho, spam_prob, 3) # ancilla 0
+        detection_rho = spam_error(detection_rho, spam_prob, 4) # ancilla 1
+
+    # -- 2nd, find the probability to measure each case
+    # ancilla in 00 -> suggests no errors -> error case00
+    # ancilla in 01 -> error on data qubit 2 -> error case01
+    # ancilla in 10 -> error on data qubit 1 -> error case10
+    # ancilla in 11 -> error on data qubit 0 -> error case11
+    error_case01, error_case10, error_case11 = 1, 2, 3
+    m00_prob = np.trace(np.dot(measure00.conj().T, np.dot(measure00, detection_rho))).real
+    m01_prob = np.trace(np.dot(measure01.conj().T, np.dot(measure01, detection_rho))).real
+    m10_prob = np.trace(np.dot(measure10.conj().T, np.dot(measure10, detection_rho))).real
+    m11_prob = np.trace(np.dot(measure11.conj().T, np.dot(measure11, detection_rho))).real
+    all_probs = np.array([m00_prob, m01_prob, m10_prob, m11_prob])
+    assert np.isclose(np.sum(all_probs), 1.0), "Invalid measurement space in three_qubit_realistic"
+    # -- 3rd, measure via probability weighted choice
+    error_case = random.choices(
+        list(range(len(all_probs))), weights=all_probs, k=1
+    )[0]
+    # -- 4th, measurement collapse of the density matrix
+    detection_rho = np.dot(
+        all_meas[error_case],
+        np.dot(detection_rho, all_meas[error_case].conj().T)
+    ) / (all_probs[error_case])
+
+    # Apply correction gates based on ancilla measurements & reset ancilla qubits
+    corrected_rho = detection_rho
+    # -- 1st, find error index
+    error_qubit_index = None
+    if error_case == error_case11:
+        error_qubit_index = 0
+        correction_gate = np.kron(sigma_x, np.identity(2**4))
+        corrected_rho = np.dot(
+            correction_gate,
+            np.dot(corrected_rho, correction_gate.conj().T)
+        )
+        ancilla_reset_gate = np.kron(np.kron(np.identity(2**3), sigma_x), sigma_x)
+        corrected_rho = np.dot(
+            ancilla_reset_gate,
+            np.dot(corrected_rho, ancilla_reset_gate.conj().T)
+        )
+        if apply_krauss_errors:
+            corrected_rho = gate_error(corrected_rho, qubit_error_probs[3], 3, nqubits)
+            corrected_rho = gate_error(corrected_rho, qubit_error_probs[4], 4, nqubits)
+    elif error_case == error_case10:
+        error_qubit_index = 1
+        correction_gate = np.kron(np.identity(2), np.kron(sigma_x, np.identity(2**3)))
+        corrected_rho = np.dot(
+            correction_gate, np.dot(corrected_rho, correction_gate.conj().T)
+        )
+        ancilla_reset_gate = np.kron(np.kron(np.identity(2**3), sigma_x), np.identity(2))
+        corrected_rho = np.dot(
+            ancilla_reset_gate,
+            np.dot(corrected_rho, ancilla_reset_gate.conj().T)
+        )
+        if apply_krauss_errors:
+            corrected_rho = gate_error(corrected_rho, qubit_error_probs[3], 3, nqubits)
+    elif error_case == error_case01:
+        error_qubit_index = 2
+        correction_gate = np.kron(np.identity(2**2), np.kron(sigma_x, np.identity(2**2)))
+        corrected_rho = np.dot(
+            correction_gate, np.dot(corrected_rho, correction_gate.conj().T)
+        )
+        ancilla_reset_gate = np.kron(np.identity(2**4), sigma_x)
+        corrected_rho = np.dot(
+            ancilla_reset_gate,
+            np.dot(corrected_rho, ancilla_reset_gate.conj().T)
+        )
+        if apply_krauss_errors:
+            corrected_rho = gate_error(corrected_rho, qubit_error_probs[4], 4, nqubits)
+    # -- 2nd, apply Krauss errors for state correction if appropriate
+    if (error_qubit_index is not None) and apply_krauss_errors:
+        corrected_rho = gate_error(
+            corrected_rho, qubit_error_probs[error_qubit_index], error_qubit_index, nqubits
+        )
+    # -- 3rd, apply RAD errors -> assume data and ancilla qubit operations are in paralllel
+    if (error_qubit_index is not None) and apply_rad_errors:
+        corrected_rho = rad_error(corrected_rho, t1, t2, tg)
+
+    return corrected_rho
+
+
+def three_qubit_realistic_santi(
+        initial_rho, t1=None, t2=None, tg=None,
+        qubit_error_probs = None, spam_prob = None
+    ): # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements,too-many-branches
+    """
+    Implements the 3 qubit circuit with relaxation and dephasing errors, gate
+    error probabilities, and spam errors.
+
+    Outputs the logical state with reset ancilla after correction.
+
+    * initial_rho: initial density matrix of your 5 qubit system
+    * t1: The relaxation time of each physical qubit in your system
+    * t2: The dephasing time of each physical qubit in your system
+    * tg: The gate time of your gate operations
+    * qubit_error_probs: an array of the probability for errors of each qubit in your system
+    * spam_prob: The pobability that you have a state prep or measurement error
+    Note: times are in seconds.
+
+    GP - I think this function makes an inappropriate measurement step at the end.
+    It cannot functon correctly if there are no RAD errors.
     """
     # total number of qubits in our system
     n = int(np.log(len(initial_rho))/np.log(2)) # pylint: disable=invalid-name
@@ -247,6 +380,11 @@ def three_qubit_realistic(
 
     # Reset the ancillas by projecting to the |00><00| basis
     # apply correct measurement collapse of the density matrix
+    #
+    # GP - this is a redundant "measurement" and will fail if there are no RAD
+    # errors (it is possible to have very valid states where projection to M1
+    # will have zero overlap - but RAD errors ensure you always have some non-zero
+    # probability there)
     ancilla_reset_prob = np.trace(np.dot(M1.conj().T, np.dot(M1, corrected_rho)))
     reset_rho = np.dot(M1, np.dot(corrected_rho, M1.conj().T))/(ancilla_reset_prob)
 

--- a/general_qec/errors.py
+++ b/general_qec/errors.py
@@ -280,6 +280,9 @@ def rad_error(rho, t1, t2, tg): # pylint: disable=invalid-name,too-many-locals
     * t2: the dephasing time of the qubits
     * tg: length in time of the logical gate you are applying
     """
+    # TODO: we don't yet handle only depolarizing or dephasing... bail if one is None
+    if ((t1 is None) or (t2 is None) or (tg is None)):
+        return rho
     # total number of qubits in your system
     tot_qubits = int(np.log(len(rho))/np.log(2))
 

--- a/tests/test_realistic_codes.py
+++ b/tests/test_realistic_codes.py
@@ -4,11 +4,12 @@ Usage:
 '''
 import unittest
 import logging
-import random
 import sys
+import random
 import numpy as np
 from general_qec.errors import random_qubit_x_error
-from general_qec.qec_helpers import one
+from general_qec.gates import cnot
+from general_qec.qec_helpers import zero, one, superpos
 from general_qec.qec_helpers import collapse_dm
 from circuit_specific.realistic_three_qubit import initialize_three_qubit_realisitc
 from circuit_specific.realistic_three_qubit import three_qubit_realistic
@@ -20,55 +21,168 @@ class TestRealisticThreeQubit(unittest.TestCase):
     """Tests for the `realistic_three_qubit` module."""
 
     def test_three_qubit_realistic_full(self):
-        """Pseudo-functional test of `three_qubit_realistic_full()`"""
+        """Test of `three_qubit_realistic()` with RAD and Krauss errors"""
         LOGGER.info(sys._getframe().f_code.co_name) # pylint: disable=protected-access
+        random.seed(10)
         initial_psi = one # initialize our psi
         # timing parameters in microseconds
         t1 = 200 * 10**-6 # pylint: disable=invalid-name
         t2 = 150 * 10**-6 # pylint: disable=invalid-name
         tg = 20 * 10**-9  # pylint: disable=invalid-name
         # probability of gate error for each of five qubits
-        # -- these are tiny errors and low likelihood
-        p_q0 = 0.0001
-        p_q1 = 0.0001
-        p_q2 = 0.00001
-        p_q3 = 0.0001
-        p_q4 = 0.000001
+        krauss_probs = [0.001] * 5
         # state preparation and measurement errors
-        spam_prob = 0.00001
-        # define your error probability for each qubit
-        qubit_error_probs = np.array([p_q0, p_q1, p_q2, p_q3, p_q4])
-        # TODO: test more initalization cases... (Nones, etc.)
+        spam_prob = 0.001
+        # initialize the circuit
+        initial_rho = initialize_three_qubit_realisitc(
+            initial_psi, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        # 5 qubits initialized into |11100>
+        initial_state = collapse_dm(initial_rho)
+        self.assertTrue(initial_rho.shape, (2**5, 2**5))
+        self.assertEqual(
+            np.unravel_index(initial_rho.argmax(), initial_rho.shape), (0b11100, 0b11100)
+        )
+        # apply the 3 qubit circuit to case with no errors
+        rho = three_qubit_realistic(
+            initial_rho, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        # errors are low, so most probable state is the same
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
+        # throw some errors: qubit 0 -> 01100, qubit 1 -> 10100, qubit 2 -> 11000
+        for (qubit, state) in [(0, 0b01100), (1, 0b10100), (2, 0b11000)]:
+            errored_state, _ = random_qubit_x_error(initial_state, (qubit, qubit))
+            self.assertEqual(np.argmax(errored_state), state)
+            rho = np.outer(errored_state, errored_state.conj().T)
+            # repair it
+            rho = three_qubit_realistic(
+                rho, t1=t1, t2=t2, tg=tg,
+                qubit_error_probs=krauss_probs, spam_prob=spam_prob
+            )
+            self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
+
+    def test_three_qubit_realistic_noerr_superpos(self):
+        """Test of `three_qubit_realistic()` with no errors"""
+        LOGGER.info(sys._getframe().f_code.co_name) # pylint: disable=protected-access
+        initial_psi = superpos # initialize our psi
+        # timing parameters in microseconds
+        t1 = None # pylint: disable=invalid-name
+        t2 = None # pylint: disable=invalid-name
+        tg = None # pylint: disable=invalid-name
+        # probability of gate error for each of five qubits
+        krauss_probs = [0.0] * 5
+        # state preparation and measurement errors
+        spam_prob = 0.0
+        # initialize the circuit
+        initial_rho = initialize_three_qubit_realisitc(
+            initial_psi, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        # 5 qubits initialized into |11100>
+        initial_state = np.kron(np.kron(np.kron(np.kron(superpos, zero), zero), zero), zero)
+        op1 = np.kron(cnot, np.identity(2**3))
+        initial_state = np.dot(op1, initial_state)
+        op2 = np.kron(np.kron(np.identity(2), cnot), np.identity(2**2))
+        initial_state = np.dot(op2, initial_state)
+        direct_rho = np.outer(initial_state, initial_state.conj().T)
+        self.assertTrue(initial_rho.shape, (2**5, 2**5))
+        self.assertTrue(np.allclose(direct_rho, initial_rho))
+        # apply the 3 qubit circuit to case with no errors
+        rho = three_qubit_realistic(
+            initial_rho, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        self.assertTrue(np.allclose(rho, initial_rho))
+        # throw some errors: qubit 0 -> 01100, qubit 1 -> 10100, qubit 2 -> 11000
+        for qubit in range(3):
+            errored_state, _ = random_qubit_x_error(initial_state, (qubit, qubit))
+            rho = np.outer(errored_state, errored_state.conj().T)
+            # repair it
+            rho = three_qubit_realistic(
+                rho, t1=t1, t2=t2, tg=tg,
+                qubit_error_probs=krauss_probs, spam_prob=spam_prob
+            )
+            self.assertTrue(np.allclose(rho, initial_rho))
+
+    def test_three_qubit_realistic_rad(self):
+        """Test of `three_qubit_realistic()` with RAD errors"""
+        LOGGER.info(sys._getframe().f_code.co_name) # pylint: disable=protected-access
+        random.seed(10)
+        initial_psi = one # initialize our psi
+        # timing parameters in microseconds
+        t1 = 200 * 10**-6 # pylint: disable=invalid-name
+        t2 = 150 * 10**-6 # pylint: disable=invalid-name
+        tg = 20 * 10**-9  # pylint: disable=invalid-name
+        # probability of gate error for each of five qubits
+        krauss_probs = [0.0] * 5
+        # state preparation and measurement errors
+        spam_prob = 0.001
+        # initialize the circuit
         rho = initialize_three_qubit_realisitc(
             initial_psi, t1=t1, t2=t2, tg=tg,
-            qubit_error_probs=qubit_error_probs, spam_prob=spam_prob
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
         )
-        # collapse density matrix when measuring after we initialized our
-        # logical state
-        random.seed(10)
-        collapsed_state = collapse_dm(rho)
-        self.assertAlmostEqual(collapsed_state[28], 1+0j)
+        self.assertTrue(rho.shape, (2**5, 2**5))
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
         # apply the 3 qubit circuit
         rho = three_qubit_realistic(
             rho, t1=t1, t2=t2, tg=tg,
-            qubit_error_probs=qubit_error_probs, spam_prob=spam_prob
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
         )
-        # collapse density matrix when measuring after we run the circuit.
-        random.seed(10)
+        # errors are low, so most probable state is the same
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
         collapsed_state = collapse_dm(rho)
-        self.assertAlmostEqual(collapsed_state[28], 1+0j)
         # throw an x error on the data qubits
         errored_state, _ = random_qubit_x_error(collapsed_state, (1,1))
-        self.assertAlmostEqual(errored_state[28], 0+0j)
+        self.assertEqual(np.argmax(errored_state), 0b10100)
         rho = np.outer(errored_state, errored_state.conj().T)
         # repair it
         rho = three_qubit_realistic(
             rho, t1=t1, t2=t2, tg=tg,
-            qubit_error_probs=qubit_error_probs, spam_prob=spam_prob
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
         )
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
+
+    def test_three_qubit_realistic_krauss(self):
+        """Test of `three_qubit_realistic()` with Krauss errors"""
+        LOGGER.info(sys._getframe().f_code.co_name) # pylint: disable=protected-access
         random.seed(10)
+        initial_psi = one # initialize our psi
+        # timing parameters in microseconds
+        t1 = None # pylint: disable=invalid-name
+        t2 = None # pylint: disable=invalid-name
+        tg = None # pylint: disable=invalid-name
+        # probability of gate error for each of five qubits
+        krauss_probs = [0.001] * 5
+        # state preparation and measurement errors
+        spam_prob = 0.001
+        # initialize the circuit
+        rho = initialize_three_qubit_realisitc(
+            initial_psi, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        self.assertTrue(rho.shape, (2**5, 2**5))
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
+        # apply the 3 qubit circuit
+        rho = three_qubit_realistic(
+            rho, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        # errors are low, so most probable state is the same
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
         collapsed_state = collapse_dm(rho)
-        self.assertAlmostEqual(collapsed_state[28], 1+0j)
+        # throw an x error on the data qubits
+        errored_state, _ = random_qubit_x_error(collapsed_state, (1,1))
+        self.assertEqual(np.argmax(errored_state), 0b10100)
+        rho = np.outer(errored_state, errored_state.conj().T)
+        # repair it
+        rho = three_qubit_realistic(
+            rho, t1=t1, t2=t2, tg=tg,
+            qubit_error_probs=krauss_probs, spam_prob=spam_prob
+        )
+        self.assertEqual(np.unravel_index(rho.argmax(), rho.shape), (0b11100, 0b11100))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
new implementation of `three_qubit_realistic`; expanded test coverage

I think the prior version (renamed `three_qubit_realistic_santi` makes an incorrectmeasurement step at the end (ancillae already measured above). The old version always failed if RAD errors were turned off...